### PR TITLE
Fixes missing username in new user email

### DIFF
--- a/modules/custom-email/custom-email.php
+++ b/modules/custom-email/custom-email.php
@@ -846,7 +846,7 @@ class Theme_My_Login_Custom_Email extends Theme_My_Login_Abstract {
 		$wpdb->update( $wpdb->users, array( 'user_activation_key' => $hashed ), array( 'user_login' => $user->user_login ) );
 
 		if ( apply_filters( 'send_new_user_notification', true ) ) {
-			$message  = sprintf( __( 'Username: %s', 'theme-my-login' ), $user_login     ) . "\r\n\r\n";
+			$message  = sprintf( __( 'Username: %s', 'theme-my-login' ), $user->user_login     ) . "\r\n\r\n";
 			$message .= __( 'To set your password, visit the following address:', 'theme-my-login' ) . "\r\n\r\n";
 			$message .= '<' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . ">\r\n\r\n";
 


### PR DESCRIPTION
With the Custom Email module active, and the New User email message left blank, the username was missing from the email. This fixes that issue.
